### PR TITLE
Add a column to optionally associate stls with a badge.

### DIFF
--- a/alembic/versions/508367dcbbb5_add_an_stl_column_fo.py
+++ b/alembic/versions/508367dcbbb5_add_an_stl_column_fo.py
@@ -1,0 +1,24 @@
+"""Add an stl column for badges.
+
+Revision ID: 508367dcbbb5
+Revises: 2879ed5a6297
+Create Date: 2014-07-11 09:36:33.211281
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '508367dcbbb5'
+down_revision = '2879ed5a6297'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('badges', sa.Column('stl', sa.Unicode(128)))
+
+
+def downgrade():
+    # Downgrade will fail if using SQLite. The transaction will
+    # be rolled back as per env.py.
+    op.drop_column('badges', 'stl')

--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -67,6 +67,7 @@ class Badge(DeclarativeBase):
     id = Column(Unicode(128), primary_key=True, default=badge_id_default)
     name = Column(Unicode(128), nullable=False, unique=True)
     image = Column(Unicode(128), nullable=False)
+    stl = Column(Unicode(128))
     description = Column(Unicode(128), nullable=False)
     criteria = Column(Unicode(128), nullable=False)
     authorizations = relationship("Authorization", backref="badge")


### PR DESCRIPTION
This will be nice now that @hroncok has provided us with stls:
https://git.fedorahosted.org/cgit/badges.git/tree/stls

..and with a method to generate them:
https://git.fedorahosted.org/cgit/badges.git/tree/bin
