### PR TITLE
Skip badges with series in populate script

### DIFF
--- a/tahrir_api/scripts/populateseries.py
+++ b/tahrir_api/scripts/populateseries.py
@@ -117,6 +117,9 @@ def main(argv=sys.argv):
 
     with transaction.manager:
         for badge in DBSession.query(Badge).all():
+            if badge.milestone:
+                # Skip badges that already are in some series.
+                continue
             series_name, ordering = get_series_name(badge.name)
             if series_name and ordering:
                 series = DBSession.query(Series).filter(Series.name == series_name).first()


### PR DESCRIPTION
Without this patch re-running the script with some of the needed series
created would lead to IntegrityError exception.