### PR TITLE
SQLAlchemy: explicitly declare order_by expression as text (#36)

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -6,7 +6,7 @@
 from .utils import autocommit, convert_name_to_id
 from .model import Badge, Invitation, Issuer, Assertion, Person, Authorization
 from .model import Team, Series, Milestone
-from sqlalchemy import create_engine, func, and_, not_
+from sqlalchemy import create_engine, func, and_, not_, text
 from sqlalchemy.orm import sessionmaker, scoped_session
 from datetime import datetime, timedelta
 
@@ -1019,7 +1019,7 @@ class TahrirDatabase(object):
             )
 
         leaderboard = (
-            leaderboard.order_by("count_1 desc")
+            leaderboard.order_by(text("count_1 desc"))
             .filter(not_(Person.opt_out))
             .group_by(Person)
             .all()


### PR DESCRIPTION
See: https://docs.sqlalchemy.org/en/13/changelog/migration_13.html#coercion-of-string-sql-fragments-to-text-fully-removed

This was a warning for years, but with 1.3 it's an error. If we
don't do this, Tahrir blows up.

Signed-off-by: Adam Williamson <awilliam@redhat.com>