### PR TITLE
Replace deprecated ZopeTransactionExtension with ZopeTransactionEvents

### DIFF
--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -15,9 +15,9 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker, relationship
 
 
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import ZopeTransactionEvents
 
-DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+DBSession = scoped_session(sessionmaker(extension=ZopeTransactionEvents()))
 DeclarativeBase = declarative_base()
 DeclarativeBase.query = DBSession.query_property()
 


### PR DESCRIPTION
The zope.sqlalchemy project has renamed ZopeTransactionExtension to ZopeTransactionEvents as of version 1.2 (https://pypi.org/project/zope.sqlalchemy/#id1).