### PR TITLE
Let flask_admin peek defaults without crashing

### DIFF
--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -36,6 +36,9 @@ class Issuer(DeclarativeBase):
 
 
 def generate_default_id(context):
+    # Allow flask_admin to peek without crashing.
+    if not context:
+        return None
     return context.current_parameters["name"].lower().replace(" ", "-")
 
 
@@ -182,8 +185,8 @@ class Person(DeclarativeBase):
         )
 
 
-def invitation_id_default(context):
-    return hashlib.md5(salt_default(context).encode("utf-8")).hexdigest()
+def invitation_id_default():
+    return hashlib.md5(salt_default().encode("utf-8")).hexdigest()
 
 
 class Invitation(DeclarativeBase):
@@ -236,6 +239,9 @@ class CurrentValue(DeclarativeBase):
 
 
 def recipient_default(context):
+    # Allow flask_admin to peek without crashing.
+    if not context:
+        return None
     person_id = context.current_parameters["person_id"]
     salt = context.current_parameters["salt"]
     person_email = context.connection.scalar(select(Person.email).where(Person.id == person_id))
@@ -246,11 +252,14 @@ def get_assertion_recipient(email, salt):
     return hashlib.sha256((email + salt).encode("utf-8")).hexdigest()
 
 
-def salt_default(context):
+def salt_default():
     return str(uuid.uuid4())
 
 
 def assertion_id_default(context):
+    # Allow flask_admin to peek without crashing.
+    if not context:
+        return None
     person_id = context.current_parameters["person_id"]
     badge_id = context.current_parameters["badge_id"]
     return f"{badge_id} -> {person_id}"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import NoInspectionAvailable
+from sqlalchemy.orm import Mapper
+
+from tahrir_api import model
+
+
+def get_models_columns_with_defaults():
+    models_columns_as_params = []
+
+    for name, thing in model.__dict__.items():
+        if isinstance(thing, type):
+            try:
+                inspected = inspect(thing)
+            except NoInspectionAvailable:
+                continue
+
+            if isinstance(inspected, Mapper):
+                for colname, column in inspected.c.items():
+                    default = getattr(column, "default", None)
+                    if default is None:
+                        continue
+                    if hasattr(default, "arg"):
+                        models_columns_as_params.append(
+                            pytest.param(column, id=f"{name}.{colname}"))
+
+    return models_columns_as_params
+
+
+@pytest.mark.parametrize("column", get_models_columns_with_defaults())
+def test_safe_column_default(column):
+    if getattr(column.default, "is_callable", False):
+        column.default.arg(None)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,7 +23,8 @@ def get_models_columns_with_defaults():
                         continue
                     if hasattr(default, "arg"):
                         models_columns_as_params.append(
-                            pytest.param(column, id=f"{name}.{colname}"))
+                            pytest.param(column, id=f"{name}.{colname}")
+                        )
 
     return models_columns_as_params
 


### PR DESCRIPTION
The flask_admin database frontend attempts to peek column default values to fill form fields, but calls the functions generating dynamic defaults with a context of None. Paper over this.

Fixes: #89