### PR TITLE
Implement the `UPDATE` operations on the `BADGES` relation

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -445,6 +445,45 @@ class TahrirDatabase:
             self.session.flush()
         return badge_id
 
+    @autocommit
+    def update_badge(self, badge_id: str, **kwargs):
+        """
+        Update a badge in the database
+
+        :type badge_id: str
+        :param badge_id: Badge ID
+        :param kwargs: Fields to update. Allowed fields are:
+            - name: Badge name
+            - image: Badge image URL
+            - description: Badge description
+            - criteria: Badge criteria
+            - tags: Badge tags (comma will be auto-appended if missing)
+
+        :raises KeyError: If invalid field names are provided
+        :returns: badge_id if successful, False if badge doesn't exist
+        """
+
+        badge = self.get_badge(badge_id)
+        if not badge:
+            return False
+
+        # List of allowed fields to update
+        allowed_fields = ["name", "image", "description", "criteria", "tags"]
+
+        # Check for invalid fields
+        invalid_fields = set(kwargs.keys()) - set(allowed_fields)
+        if invalid_fields:
+            raise KeyError(f"Invalid fields: {invalid_fields}")
+
+        for attr, value in kwargs.items():
+            # Special handling for tags
+            if attr == "tags":
+                value = value + "," if value and not value.endswith(",") else value
+            setattr(badge, attr, value)
+
+        self.session.flush()
+        return badge_id
+
     def person_exists(self, email=None, id=None, nickname=None):
         """
         Check if a Person with this email is stored in the database

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -242,3 +242,69 @@ def test_remove_assertion_nonexistent_assertion(api, dummy_badge_id, dummy_perso
     """Test removing non-existent assertion returns False"""
     result = api.remove_assertion(dummy_badge_id, "test@tester.com")
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # Test individual field updates
+        {"name": "UpdatedName"},
+        {"image": "UpdatedImage"},
+        {"description": "Updated description"},
+        {"criteria": "Updated criteria"},
+        {"tags": "updated, tags"},
+        {"tags": "updated, tags,"},
+        # Test multiple field updates
+        {
+            "name": "MultiUpdate",
+            "image": "MultiImage",
+            "description": "Multi description",
+            "criteria": "Multi criteria",
+            "tags": "multi, tags",
+        },
+        # Test empty update
+        {},
+    ],
+)
+def test_update_badge(api, dummy_badge_id, kwargs):
+    """Test updating badge"""
+    # Obtain
+    existing_badge = api.get_badge(dummy_badge_id)
+
+    # Create
+    expected_name = kwargs.get("name", existing_badge.name)
+    expected_image = kwargs.get("image", existing_badge.image)
+    expected_description = kwargs.get("description", existing_badge.description)
+    expected_criteria = kwargs.get("criteria", existing_badge.criteria)
+
+    # Handle
+    if "tags" in kwargs:
+        tags = kwargs["tags"]
+        expected_tags = tags + "," if tags and not tags.endswith(",") else tags
+    else:
+        expected_tags = existing_badge.tags
+
+    # Update
+    api.update_badge(dummy_badge_id, **kwargs)
+
+    # Obtain
+    updated_badge = api.get_badge(dummy_badge_id)
+
+    # Verify
+    assert updated_badge.name == expected_name
+    assert updated_badge.image == expected_image
+    assert updated_badge.description == expected_description
+    assert updated_badge.criteria == expected_criteria
+    assert updated_badge.tags == expected_tags
+
+
+def test_update_badge_nonexistent(api):
+    """Test updating badge which are non-existent and returns False"""
+    result = api.update_badge("nonexistent_badge_id", name="UpdatedName")
+    assert result is False
+
+
+def test_update_badge_invalid_fields(api, dummy_badge_id):
+    """Test updating badge with invalid fields and raises KeyError"""
+    with pytest.raises(KeyError, match="Invalid fields"):
+        api.update_badge(dummy_badge_id, invalid_field="value")


### PR DESCRIPTION
This PR implements the `UPDATE` operations on the `BADGES` relation.

### Summary
- Implements `update_badge` method in TahrirDatabase class for `UPDATE` operation
- Adds comprehensive parameterised tests covering all field update scenarios

### Changes
- Added `update_badge` method with `autocommit` decorator
- Supports updating name, image, description, criteria, and tags
- Handles tag formatting (ensures comma suffix)
- Returns badge_id on success, False for non-existent badges
- Test all possible scenarios while updating the badge information

I was thinking about adding a new column `updated_on` in `BADGES` relation. Let me know if it sound good, I'll add it then. Also, let me know if any other changes are needed.

Fixes: #197 