### PR TITLE
feat: add pagination and ordering to `get_all_assertions` method

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -4,6 +4,7 @@
 
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from sqlalchemy import and_, func, not_, select, text
 from tahrir_messages import BadgeAwardV1, PersonLoginFirstV1, PersonRankAdvanceV1
@@ -860,12 +861,23 @@ class TahrirDatabase:
 
         return self.session.query(Issuer)
 
-    def get_all_assertions(self):
+    def get_all_assertions(self, begin: Optional[int] = None, limit: Optional[int] = None):
         """
-        Get all assertions in the db.
+        Get all assertions in the db, ordered by most recent first.
+
+        :type begin: int
+        :param begin: Number of assertions to skip (offset for pagination, default: 0)
+
+        :type limit: int
+        :param limit: Maximum number of assertions to return (default: 100)
         """
 
-        return self.session.query(Assertion)
+        result = self.session.query(Assertion).order_by(Assertion.issued_on.desc())
+
+        if begin is not None or limit is not None:
+            result = result.offset(begin or 0).limit(limit)
+
+        return result
 
     def get_assertions_by_email(self, person_email):
         """

--- a/tahrir_api/migrations/versions/459d4cc47d13_add_index_on_assertions_issued_on_column.py
+++ b/tahrir_api/migrations/versions/459d4cc47d13_add_index_on_assertions_issued_on_column.py
@@ -1,0 +1,23 @@
+"""add index on assertions issued_on column
+
+Revision ID: 459d4cc47d13
+Revises: 51261da641fb
+Create Date: 2025-10-18 09:06:20.131085
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "459d4cc47d13"
+down_revision = "51261da641fb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("ix_assertions_issued_on", "assertions", ["issued_on"])
+
+
+def downgrade():
+    op.drop_index("ix_assertions_issued_on", "assertions")

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -26,6 +26,20 @@ def dummy_person_id(api):
     return api.add_person("test@tester.com")
 
 
+@pytest.fixture
+def initialize_list_assertions(api, dummy_person_id, dummy_issuer_id):
+    for unit in range(0, 10):
+        tmpbadge = api.add_badge(
+            f"AsrtName_{unit}",
+            f"AsrtShot_{unit}",
+            f"AsrtDesc_{unit}",
+            f"AsrtCrit_{unit}",
+            dummy_issuer_id,
+        )
+        api.add_assertion(tmpbadge, "test@tester.com", None, f"link_{unit}")
+    return 10
+
+
 def test_add_badges(api, dummy_badge_id):
     assert api.get_badge("testbadge").__str__() == "TestBadge"
     assert api.badge_exists("testbadge") is True
@@ -416,3 +430,31 @@ def test_update_person_nonexistent(api, identifier_type, identifier_value):
     update_args["website"] = "https://example.com"
     result = api.update_person(**update_args)
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "begin, limit, expected_count",
+    [
+        (None, None, 10),
+        (0, 5, 5),
+        (5, 5, 5),
+        (0, 20, 10),
+        (5, None, 5),
+        (5, 10, 5),
+        (10, 10, 0),
+        (None, 0, 0),
+        (0, 1, 1),
+    ],
+)
+def test_get_all_assertions(api, initialize_list_assertions, begin, limit, expected_count):
+    """Test get_all_assertions with various begin and limit parameters."""
+    assertions = list(api.get_all_assertions(begin=begin, limit=limit))
+
+    assert len(assertions) == expected_count
+    if len(assertions) > 1:
+        assert assertions[0].issued_on >= assertions[1].issued_on
+
+    if begin is not None and begin > 0 and expected_count > 0:
+        first_batch = list(api.get_all_assertions(begin=0, limit=expected_count))
+        if len(first_batch) == expected_count:
+            assert assertions[0].id != first_batch[0].id


### PR DESCRIPTION
feat: add pagination and ordering to `get_all_assertions` method

This should not cause problems with the existing usages of `get_all_assertions` but we need to replace those unoptimal uses as soon as possible.