### PR TITLE
Add missing `autocommit` decorator on `expire_invitation`

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -779,6 +779,7 @@ class TahrirDatabase:
 
         return self.session.query(Invitation).filter_by(created_by=person_id).all()
 
+    @autocommit
     def expire_invitation(self, invitation_id):
         """
         Soft-delete an invitation by setting its expiry date to the current time.


### PR DESCRIPTION
## Summary
Adds the missing `@autocommit` decorator to the `expire_invitation` function to ensure database transactions are properly committed when expiring invitations.

## Problem
The `expire_invitation` function in `tahrir_api/dbapi.py` was missing the `@autocommit` decorator, causing database updates to not be persisted when the DELETE `/api/admin/invitations` endpoint was called (implemented in fedora-infra/tahrir#757).

## Solution
Added the `@autocommit` decorator to the `expire_invitation` function at line 782, consistent with other database modification functions in the codebase.

Fixes #224

<img width="863" height="167" alt="Screenshot From 2025-11-03 22-14-21" src="https://github.com/user-attachments/assets/1388fa43-1fbc-4502-8986-39451e7fd245" />
<img width="1108" height="449" alt="Screenshot From 2025-11-03 22-14-14" src="https://github.com/user-attachments/assets/2b15d486-00b7-4889-8837-5f10a45dbf4b" />