### PR TITLE
Add get_persons_by_nickname with pagination to TahrirDatabase

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -547,22 +547,9 @@ class TahrirDatabase:
         )
         total_count = query.count()
         paginated_results = query.offset(begin).limit(safe_limit).all()
-        users = [
-            {
-                "id": person.id,
-                "bio": person.bio if person.bio else None,
-                "created_on": person.created_on.timestamp() if person.created_on else None,
-                "email": person.avatar,  # the endpoint handles the hashing
-                "last_login": person.last_login.timestamp() if person.last_login else None,
-                "nickname": person.nickname,
-                "opt_out": person.opt_out,
-                "rank": person.rank,
-                "website": person.website,
-            }
-            for person in paginated_results
-        ]
+
         return {
-            "users": users,
+            "users": paginated_results,
             "total": total_count,
             "begin": begin,
             "limit": safe_limit,

--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -531,6 +531,43 @@ class TahrirDatabase:
             query = query.filter(not_(Person.opt_out))
         return query
 
+    def get_persons_by_nickname(self, search_string: str, begin: int = 0, limit: int = 100):
+        """
+        Search for persons by nickname with pagination.
+        :type search_string: str
+        :param search_string: The nickname pattern to search for.
+        :type begin: int
+        :param begin: Offset for pagination (default 0).
+        :type limit: int
+        :param limit: Max results per page, capped at 100 (default 100).
+        """
+        safe_limit = min(limit, 100)
+        query = self.session.query(Person).filter(
+            func.lower(Person.nickname).like(f"%{search_string.lower()}%")
+        )
+        total_count = query.count()
+        paginated_results = query.offset(begin).limit(safe_limit).all()
+        users = [
+            {
+                "id": person.id,
+                "bio": person.bio if person.bio else None,
+                "created_on": person.created_on.timestamp() if person.created_on else None,
+                "email": person.avatar,  # the endpoint handles the hashing
+                "last_login": person.last_login.timestamp() if person.last_login else None,
+                "nickname": person.nickname,
+                "opt_out": person.opt_out,
+                "rank": person.rank,
+                "website": person.website,
+            }
+            for person in paginated_results
+        ]
+        return {
+            "users": users,
+            "total": total_count,
+            "begin": begin,
+            "limit": safe_limit,
+        }
+
     def get_person_email(self, person_id):
         """
         Convience function to retrieve a person email from an id.

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -676,6 +676,7 @@ def test_get_all_series_empty(api):
     series_list = list(series_query)
     assert len(series_list) == 0
 
+
 def test_get_persons_by_nickname(api):
     api.add_person("alice@test.com", nickname="alice_wonder")
     api.add_person("bob@test.com", nickname="bob_builder")
@@ -685,6 +686,7 @@ def test_get_persons_by_nickname(api):
     assert result["total"] == 1
     assert result["users"][0]["nickname"] == "alice_wonder"
 
+
 def test_get_persons_by_nickname_partial_match(api):
     api.add_person("dave@test.com", nickname="dave_test")
     api.add_person("diana@test.com", nickname="diana_test")
@@ -692,6 +694,7 @@ def test_get_persons_by_nickname_partial_match(api):
 
     result = api.get_persons_by_nickname("test")
     assert result["total"] == 2
+
 
 def test_get_persons_by_nickname_pagination(api):
     for i in range(5):
@@ -703,6 +706,7 @@ def test_get_persons_by_nickname_pagination(api):
     assert result["begin"] == 0
     assert result["limit"] == 2
 
+
 def test_get_persons_by_nickname_no_match(api):
     api.add_person("test@test.com", nickname="test_user")
 
@@ -710,8 +714,9 @@ def test_get_persons_by_nickname_no_match(api):
     assert result["total"] == 0
     assert result["users"] == []
 
+
 def test_get_persons_by_nickname_case_insensitive(api):
     api.add_person("upper@test.com", nickname="UpperCase")
 
     result = api.get_persons_by_nickname("uppercase")
-    assert result["total"] == 1  
+    assert result["total"] == 1

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -684,7 +684,7 @@ def test_get_persons_by_nickname(api):
 
     result = api.get_persons_by_nickname("alice")
     assert result["total"] == 1
-    assert result["users"][0]["nickname"] == "alice_wonder"
+    assert result["users"][0].nickname == "alice_wonder"
 
 
 def test_get_persons_by_nickname_partial_match(api):

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -675,3 +675,43 @@ def test_get_all_series_empty(api):
     series_query = api.get_all_series()
     series_list = list(series_query)
     assert len(series_list) == 0
+
+def test_get_persons_by_nickname(api):
+    api.add_person("alice@test.com", nickname="alice_wonder")
+    api.add_person("bob@test.com", nickname="bob_builder")
+    api.add_person("charlie@test.com", nickname="charlie_choc")
+
+    result = api.get_persons_by_nickname("alice")
+    assert result["total"] == 1
+    assert result["users"][0]["nickname"] == "alice_wonder"
+
+def test_get_persons_by_nickname_partial_match(api):
+    api.add_person("dave@test.com", nickname="dave_test")
+    api.add_person("diana@test.com", nickname="diana_test")
+    api.add_person("evan@test.com", nickname="evan_other")
+
+    result = api.get_persons_by_nickname("test")
+    assert result["total"] == 2
+
+def test_get_persons_by_nickname_pagination(api):
+    for i in range(5):
+        api.add_person(f"user{i}@test.com", nickname=f"user_{i}")
+
+    result = api.get_persons_by_nickname("user", begin=0, limit=2)
+    assert len(result["users"]) == 2
+    assert result["total"] == 5
+    assert result["begin"] == 0
+    assert result["limit"] == 2
+
+def test_get_persons_by_nickname_no_match(api):
+    api.add_person("test@test.com", nickname="test_user")
+
+    result = api.get_persons_by_nickname("zzznomatch")
+    assert result["total"] == 0
+    assert result["users"] == []
+
+def test_get_persons_by_nickname_case_insensitive(api):
+    api.add_person("upper@test.com", nickname="UpperCase")
+
+    result = api.get_persons_by_nickname("uppercase")
+    assert result["total"] == 1  


### PR DESCRIPTION
Add `get_persons_by_nickname` method to `TahrirDatabase` to support paginated user search by nickname.

This moves the user search and pagination logic from the tahrir frontend into the API layer where it belongs. The method accepts a search string, begin offset, and limit, and returns a dict with the matching users, total count, and pagination info.