### PR TITLE
Fix cascade delete for badge assertions 

### DIFF
--- a/tahrir_api/migrations/versions/53b73809290f_add_ondelete_cascade_to_badge_assertions.py
+++ b/tahrir_api/migrations/versions/53b73809290f_add_ondelete_cascade_to_badge_assertions.py
@@ -1,0 +1,28 @@
+"""Add ondelete cascade to badge assertions
+
+Revision ID: 53b73809290f
+Revises: 459d4cc47d13
+Create Date: 2026-04-10 23:02:35.121330
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "53b73809290f"
+down_revision = "459d4cc47d13"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("assertions", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_assertions_badge_id_badges", type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_assertions_badge_id_badges", "badges", ["badge_id"], ["id"], ondelete="CASCADE"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("assertions", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_assertions_badge_id_badges", type_="foreignkey")
+        batch_op.create_foreign_key("fk_assertions_badge_id_badges", "badges", ["badge_id"], ["id"])

--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -80,7 +80,7 @@ class Badge(DeclarativeBase):
     issuer_id = Column(Integer, ForeignKey("issuers.id"), nullable=False)
     milestone = relationship("Milestone", backref="badge")
     authorizations = relationship("Authorization", backref="badge")
-    assertions = relationship("Assertion", backref="badge")
+    assertions = relationship("Assertion", backref="badge", passive_deletes=True)
     invitations = relationship("Invitation", backref="badge")
     current_values = relationship("CurrentValue", back_populates="badge")
     created_on = Column(DateTime, nullable=False, default=datetime.datetime.now)
@@ -301,7 +301,7 @@ def assertion_id_default(context):
 class Assertion(DeclarativeBase):
     __tablename__ = "assertions"
     id = Column(Unicode(128), primary_key=True, unique=True, default=assertion_id_default)
-    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False)
+    badge_id = Column(Unicode(128), ForeignKey("badges.id", ondelete="CASCADE"), nullable=False)
     person_id = Column(Integer, ForeignKey("persons.id"), nullable=False)
     salt = Column(Unicode(128), nullable=False, default=salt_default)
     issued_on = Column(DateTime, nullable=False, default=datetime.datetime.now)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -33,3 +33,25 @@ def get_models_columns_with_defaults():
 def test_safe_column_default(column):
     if getattr(column.default, "is_callable", False):
         column.default.arg(None)
+
+
+def test_badge_assertion_cascade_delete(api):
+    """
+    Verify that deleting a badge automatically removes associated assertions.
+    """
+    session = api.session
+    issuer_id = api.add_issuer("TestOrigin", "TestIssuer", "TestOrg", "TestContact")
+    api.add_person("cascade@example.com")
+    badge_id = api.add_badge(
+        "CascadeBadge", "TestImage", "Testing delete", "TestCriteria", issuer_id
+    )
+    api.add_assertion(badge_id, "cascade@example.com", None)
+    session.commit()
+
+    assert session.query(model.Assertion).filter_by(badge_id=badge_id).count() == 1
+
+    badge = api.get_badge(badge_id)
+    session.delete(badge)
+    session.commit()
+
+    assert session.query(model.Assertion).filter_by(badge_id=badge_id).count() == 0


### PR DESCRIPTION

Fixes #205 

### Problem
Deleting a badge that has associated assertions fails because the assertions.badge_id foreign key does not cascade deletes.

### Solution
This PR fixes the delete behavior by:
- Adding ondelete="CASCADE" to the assertions.badge_id foreign key
- Enabling passive_deletes=True on the Badge.

### Changes made
Updated Assertion.badge_id foreign key to use ON DELETE CASCADE and Badge.assertions to passive_deletes=True. 

This ensures deleting a badge removes all associated assertions.

<img width="958" height="164" alt="Screenshot 2026-04-10 232524" src="https://github.com/user-attachments/assets/8dc36bba-61e9-40ee-a162-42d211d921d5" />
