### PR TITLE
refactor: Unoptimized endpoints in searching for badges and persons through search string

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -377,17 +377,24 @@ class TahrirDatabase:
 
         return unique_badges
 
-    def get_all_badges(
+    def get_all_badges(self):
+        """
+        Get all badges in the db.
+        """
+
+        return self.session.query(Badge)
+
+    def get_badges_by_search_string(
         self,
-        search_string: Optional[str] = None,
+        search_string: str,
         begin: Optional[int] = None,
         limit: Optional[int] = None,
     ):
         """
-        Get all badges in the db.
+        Get all badges in the db by a search string.
 
         :type search_string: str
-        :param search_string: string to be searched for in the badges database
+        :param search_string: string to be searched for in the Badge database
 
         :type begin: int
         :param begin: Number of assertions to skip (offset for pagination, default: 0)
@@ -396,7 +403,8 @@ class TahrirDatabase:
         :param limit: Maximum number of assertions to return (default: 100)
         """
         if search_string is None:
-            search_string = ""
+            return []
+        search_string = f"{search_string}" if isinstance(search_string, (int)) else search_string
 
         begin = begin if begin is not None and isinstance(begin, (int)) else 0
         limit = limit if limit is not None and isinstance(limit, (int)) else 100
@@ -552,18 +560,28 @@ class TahrirDatabase:
         # Otherwise, return whatever value they have in the DB.
         return person.opt_out
 
-    def get_all_persons(
+    def get_all_persons(self, include_opted_out=False):
+        """
+        Gets all the persons in the db.
+        """
+
+        query = self.session.query(Person)
+        if not include_opted_out:
+            query = query.filter(not_(Person.opt_out))
+        return query
+
+    def get_persons_by_search_string(
         self,
-        search_string: Optional[str] = None,
+        search_string: str,
         begin: Optional[int] = None,
         limit: Optional[int] = None,
         include_opted_out=False,
     ):
         """
-        Gets all the persons in the db.
+        Gets all persons in the db by a search string.
 
         :type search_string: str
-        :param search_string: string to be searched for in the badges database
+        :param search_string: string to be searched for in the Person database
 
         :type begin: int
         :param begin: Number of assertions to skip (offset for pagination, default: 0)
@@ -576,7 +594,8 @@ class TahrirDatabase:
         """
 
         if search_string is None:
-            search_string = ""
+            return []
+        search_string = f"{search_string}" if isinstance(search_string, (int)) else search_string
 
         begin = begin if begin is not None and isinstance(begin, (int)) else 0
         limit = limit if limit is not None and isinstance(limit, (int)) else 100

--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -377,12 +377,43 @@ class TahrirDatabase:
 
         return unique_badges
 
-    def get_all_badges(self):
+    def get_all_badges(
+        self,
+        search_string: Optional[str] = None,
+        begin: Optional[int] = None,
+        limit: Optional[int] = None,
+    ):
         """
         Get all badges in the db.
-        """
 
-        return self.session.query(Badge)
+        :type search_string: str
+        :param search_string: string to be searched for in the badges database
+
+        :type begin: int
+        :param begin: Number of assertions to skip (offset for pagination, default: 0)
+
+        :type limit: int
+        :param limit: Maximum number of assertions to return (default: 100)
+        """
+        if search_string is None:
+            search_string = ""
+
+        begin = begin if begin is not None and isinstance(begin, (int)) else 0
+        limit = limit if limit is not None and isinstance(limit, (int)) else 100
+
+        badges = (
+            self.session.query(Badge)
+            .filter(
+                func.lower(Badge.name).like(f"%{search_string.lower()}%")
+                | func.lower(Badge.description).like(f"%{search_string.lower()}%")
+                | func.lower(Badge.tags).like(f"%{search_string.lower()}%")
+            )
+            .order_by(Badge.created_on.desc())
+            .offset(begin)
+            .limit(limit)
+        )
+
+        return badges.all()
 
     @autocommit
     def delete_badge(self, badge_id):
@@ -521,15 +552,43 @@ class TahrirDatabase:
         # Otherwise, return whatever value they have in the DB.
         return person.opt_out
 
-    def get_all_persons(self, include_opted_out=False):
+    def get_all_persons(
+        self,
+        search_string: Optional[str] = None,
+        begin: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_opted_out=False,
+    ):
         """
         Gets all the persons in the db.
+
+        :type search_string: str
+        :param search_string: string to be searched for in the badges database
+
+        :type begin: int
+        :param begin: Number of assertions to skip (offset for pagination, default: 0)
+
+        :type limit: int
+        :param limit: Maximum number of assertions to return (default: 100)
+
+        :type include_opted_out: boolean
+        :param include_opted_out: asks to return deactivated persons account or not
         """
 
-        query = self.session.query(Person)
+        if search_string is None:
+            search_string = ""
+
+        begin = begin if begin is not None and isinstance(begin, (int)) else 0
+        limit = limit if limit is not None and isinstance(limit, (int)) else 100
+
+        query = self.session.query(Person).filter(
+            func.lower(Person.nickname).like(f"%{search_string.lower()}%")
+        )
         if not include_opted_out:
             query = query.filter(not_(Person.opt_out))
-        return query
+
+        query = query.offset(begin).limit(limit)
+        return query.all()
 
     def get_person_email(self, person_id):
         """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,75 @@
+# Helpers for function specific tests can be made here to reduce
+# congestion in main test file.
+
+
+def dummy_badges_for_search_string(api, dummy_issuer_id):
+    """Seed with database with dummy badges"""
+    api.add_badge(
+        "TestBadge-1 rabbit",
+        "TestImage-2",
+        "A test badge for doing 10 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag1",
+    )
+
+    api.add_badge(
+        "TestBadge-2 panda",
+        "TestImage-2",
+        "A test badge for doing 200 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag4",
+    )
+
+    api.add_badge(
+        "TestBadge-3 rabbit panda",
+        "TestImage-4",
+        "A test badge for doing 60 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag2",
+    )
+
+    api.add_badge(
+        "TestBadge-4 deer",
+        "TestImage-2",
+        "A test badge for doing 400 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag1, tag4",
+    )
+    api.add_badge(
+        "TestBadge-5 rabbit",
+        "TestImage-3",
+        "A test badge for doing 50 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag3",
+    )
+
+    api.add_badge(
+        "TestBadge-6 deer",
+        "TestImage-5",
+        "A test badge for doing 600 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag2, tag4",
+    )
+
+    return True
+
+
+def dummy_persons_for_search_string(api):
+    data = [
+        {"nickname": "John", "email": "test1@tester.com"},
+        {"nickname": "Joshua", "email": "test2@tester.com"},
+        {"nickname": "Jane", "email": "test3@tester.com"},
+        {"nickname": "Bane", "email": "test4@tester.com"},
+        {"nickname": "pear", "email": "test5@tester.com"},
+        {"nickname": "t0xic", "email": "test6@tester.com"},
+    ]
+
+    for person in range(0, 6):
+        api.add_person(data[person]["email"], data[person]["nickname"])
+    return True

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -819,6 +819,10 @@ def test_get_all_persons(
     assert len(persons) == expected_count
 
     if begin is not None and isinstance(begin, (int)) and begin > 0 and expected_count > 0:
-        control_batch = list(api.get_all_persons(search_string, begin=0, limit=expected_count))
+        control_batch = list(
+            api.get_all_persons(
+                search_string, begin=0, limit=expected_count, include_opted_out=True
+            )
+        )
         if len(control_batch) == expected_count:
             assert persons[0].id != control_batch[0].id

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -27,6 +27,22 @@ def dummy_person_id(api):
 
 
 @pytest.fixture
+def initialize_dummy_persons(api):
+    data = [
+        {"nickname": "John", "email": "test1@tester.com"},
+        {"nickname": "Joshua", "email": "test2@tester.com"},
+        {"nickname": "Jane", "email": "test3@tester.com"},
+        {"nickname": "Bane", "email": "test4@tester.com"},
+        {"nickname": "pear", "email": "test5@tester.com"},
+        {"nickname": "t0xic", "email": "test6@tester.com"},
+    ]
+
+    for person in range(0, 6):
+        api.add_person(data[person]["email"], data[person]["nickname"])
+    return True
+
+
+@pytest.fixture
 def initialize_list_assertions(api, dummy_person_id, dummy_issuer_id):
     for unit in range(0, 10):
         tmpbadge = api.add_badge(
@@ -675,3 +691,134 @@ def test_get_all_series_empty(api):
     series_query = api.get_all_series()
     series_list = list(series_query)
     assert len(series_list) == 0
+
+
+@pytest.mark.parametrize(
+    "search_string, begin, limit, expected_count",
+    [
+        ("", None, None, 6),  # tuples with "" checks the correctness of the pagination
+        ("", 0, 3, 3),
+        ("", 4, 2, 2),
+        ("", 3, 3, 3),
+        ("", 0, 20, 6),
+        ("", 2, None, 4),
+        ("", 3, 10, 3),
+        ("", 6, 6, 0),
+        ("", None, 0, 0),
+        ("", 0, 1, 1),
+        ("", "one", "two", 6),
+        ("test badge", 0, 6, 6),  # tuples below test for correct filteration
+        ("rabbit panda", 0, 6, 1),
+        ("rabbit", 0, 6, 3),
+        ("deer", 0, 6, 2),
+        ("moose", 0, 6, 0),
+        ("600", 0, 6, 1),
+        ("60", 0, 6, 2),
+        ("500", 0, 6, 0),
+        ("tag", 0, 6, 6),
+        ("tag4", 0, 6, 3),
+        ("tag0", 0, 6, 0),
+        ("tag3", 0, 6, 1),
+        (None, 0, 6, 6),
+    ],
+)
+def test_get_all_badges(api, search_string, begin, limit, expected_count, dummy_issuer_id):
+    """Test get_all_badges with various begin and limit parameters."""
+
+    # Seed with dummy badges
+    api.add_badge(
+        "TestBadge-1 rabbit",
+        "TestImage-2",
+        "A test badge for doing 10 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag1",
+    )
+
+    api.add_badge(
+        "TestBadge-2 panda",
+        "TestImage-2",
+        "A test badge for doing 200 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag4",
+    )
+
+    api.add_badge(
+        "TestBadge-3 rabbit panda",
+        "TestImage-4",
+        "A test badge for doing 60 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag2",
+    )
+
+    api.add_badge(
+        "TestBadge-4 deer",
+        "TestImage-2",
+        "A test badge for doing 400 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag1, tag4",
+    )
+    api.add_badge(
+        "TestBadge-5 rabbit",
+        "TestImage-3",
+        "A test badge for doing 50 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag3",
+    )
+
+    api.add_badge(
+        "TestBadge-6 deer",
+        "TestImage-5",
+        "A test badge for doing 600 unit tests",
+        "TestCriteria",
+        dummy_issuer_id,
+        tags="tag2, tag4",
+    )
+
+    badges = list(api.get_all_badges(search_string, begin, limit))
+    assert len(badges) == expected_count
+
+    if len(badges) > 1:
+        assert badges[0].created_on >= badges[1].created_on
+        assert badges[0].created_on >= badges[-1].created_on
+
+    if begin is not None and isinstance(begin, (int)) and begin > 0 and expected_count > 0:
+        control_batch = list(api.get_all_badges(search_string, begin=0, limit=expected_count))
+        if len(control_batch) == expected_count:
+            assert badges[0].id != control_batch[0].id
+
+
+@pytest.mark.parametrize(
+    "search_string, begin, limit, expected_count",
+    [
+        ("", None, None, 6),  # tuples with "" checks the correctness of the pagination
+        ("", 0, 3, 3),
+        ("", 4, 2, 2),
+        ("", 3, 3, 3),
+        ("", 0, 20, 6),
+        ("", 2, None, 4),
+        ("", 3, 10, 3),
+        ("", 6, 6, 0),
+        ("", None, 0, 0),
+        ("", 0, 1, 1),
+        ("", "one", "two", 6),
+        ("jo", 0, 6, 2),  # tuples below test for correct filteration
+        ("ane", 0, 6, 2),
+        ("0x", 0, 6, 1),
+        (None, 0, 6, 6),
+    ],
+)
+def test_get_all_persons(
+    api, initialize_dummy_persons, search_string, begin, limit, expected_count
+):
+    persons = list(api.get_all_persons(search_string, begin, limit, include_opted_out=True))
+    assert len(persons) == expected_count
+
+    if begin is not None and isinstance(begin, (int)) and begin > 0 and expected_count > 0:
+        control_batch = list(api.get_all_persons(search_string, begin=0, limit=expected_count))
+        if len(control_batch) == expected_count:
+            assert persons[0].id != control_batch[0].id

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -719,10 +719,13 @@ def test_get_all_series_empty(api):
         ("tag4", 0, 6, 3),
         ("tag0", 0, 6, 0),
         ("tag3", 0, 6, 1),
-        (None, 0, 6, 6),
+        (90, 0, 6, 0),
+        (None, 0, 6, 0),
     ],
 )
-def test_get_all_badges(api, search_string, begin, limit, expected_count, dummy_issuer_id):
+def test_get_badges_by_search_string(
+    api, search_string, begin, limit, expected_count, dummy_issuer_id
+):
     """Test get_all_badges with various begin and limit parameters."""
 
     # Seed with dummy badges
@@ -779,7 +782,7 @@ def test_get_all_badges(api, search_string, begin, limit, expected_count, dummy_
         tags="tag2, tag4",
     )
 
-    badges = list(api.get_all_badges(search_string, begin, limit))
+    badges = list(api.get_badges_by_search_string(search_string, begin, limit))
     assert len(badges) == expected_count
 
     if len(badges) > 1:
@@ -787,7 +790,9 @@ def test_get_all_badges(api, search_string, begin, limit, expected_count, dummy_
         assert badges[0].created_on >= badges[-1].created_on
 
     if begin is not None and isinstance(begin, (int)) and begin > 0 and expected_count > 0:
-        control_batch = list(api.get_all_badges(search_string, begin=0, limit=expected_count))
+        control_batch = list(
+            api.get_badges_by_search_string(search_string, begin=0, limit=expected_count)
+        )
         if len(control_batch) == expected_count:
             assert badges[0].id != control_batch[0].id
 
@@ -809,18 +814,22 @@ def test_get_all_badges(api, search_string, begin, limit, expected_count, dummy_
         ("jo", 0, 6, 2),  # tuples below test for correct filteration
         ("ane", 0, 6, 2),
         ("0x", 0, 6, 1),
-        (None, 0, 6, 6),
+        (90, 0, 6, 0),
+        (0, 0, 6, 1),
+        (None, 0, 6, 0),
     ],
 )
-def test_get_all_persons(
+def test_get_persons_by_search_string(
     api, initialize_dummy_persons, search_string, begin, limit, expected_count
 ):
-    persons = list(api.get_all_persons(search_string, begin, limit, include_opted_out=True))
+    persons = list(
+        api.get_persons_by_search_string(search_string, begin, limit, include_opted_out=True)
+    )
     assert len(persons) == expected_count
 
     if begin is not None and isinstance(begin, (int)) and begin > 0 and expected_count > 0:
         control_batch = list(
-            api.get_all_persons(
+            api.get_persons_by_search_string(
                 search_string, begin=0, limit=expected_count, include_opted_out=True
             )
         )

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -4,6 +4,8 @@ import pytest
 
 from tahrir_api.model import Assertion, Authorization, Badge, Milestone, Person, Series, Team
 
+from .helpers import dummy_badges_for_search_string, dummy_persons_for_search_string
+
 
 @pytest.fixture
 def dummy_issuer_id(api):
@@ -24,22 +26,6 @@ def dummy_badge_id(api, dummy_issuer_id):
 @pytest.fixture
 def dummy_person_id(api):
     return api.add_person("test@tester.com")
-
-
-@pytest.fixture
-def initialize_dummy_persons(api):
-    data = [
-        {"nickname": "John", "email": "test1@tester.com"},
-        {"nickname": "Joshua", "email": "test2@tester.com"},
-        {"nickname": "Jane", "email": "test3@tester.com"},
-        {"nickname": "Bane", "email": "test4@tester.com"},
-        {"nickname": "pear", "email": "test5@tester.com"},
-        {"nickname": "t0xic", "email": "test6@tester.com"},
-    ]
-
-    for person in range(0, 6):
-        api.add_person(data[person]["email"], data[person]["nickname"])
-    return True
 
 
 @pytest.fixture
@@ -707,80 +693,14 @@ def test_get_all_series_empty(api):
         ("", None, 0, 0),
         ("", 0, 1, 1),
         ("", "one", "two", 6),
-        ("test badge", 0, 6, 6),  # tuples below test for correct filteration
-        ("rabbit panda", 0, 6, 1),
-        ("rabbit", 0, 6, 3),
-        ("deer", 0, 6, 2),
-        ("moose", 0, 6, 0),
-        ("600", 0, 6, 1),
-        ("60", 0, 6, 2),
-        ("500", 0, 6, 0),
-        ("tag", 0, 6, 6),
-        ("tag4", 0, 6, 3),
-        ("tag0", 0, 6, 0),
-        ("tag3", 0, 6, 1),
-        (90, 0, 6, 0),
-        (None, 0, 6, 0),
     ],
 )
-def test_get_badges_by_search_string(
+def test_get_badges_by_search_string_pagination(
     api, search_string, begin, limit, expected_count, dummy_issuer_id
 ):
-    """Test get_all_badges with various begin and limit parameters."""
+    """Test for the pagination function of get_badges_by_search_string_filter"""
 
-    # Seed with dummy badges
-    api.add_badge(
-        "TestBadge-1 rabbit",
-        "TestImage-2",
-        "A test badge for doing 10 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag1",
-    )
-
-    api.add_badge(
-        "TestBadge-2 panda",
-        "TestImage-2",
-        "A test badge for doing 200 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag4",
-    )
-
-    api.add_badge(
-        "TestBadge-3 rabbit panda",
-        "TestImage-4",
-        "A test badge for doing 60 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag2",
-    )
-
-    api.add_badge(
-        "TestBadge-4 deer",
-        "TestImage-2",
-        "A test badge for doing 400 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag1, tag4",
-    )
-    api.add_badge(
-        "TestBadge-5 rabbit",
-        "TestImage-3",
-        "A test badge for doing 50 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag3",
-    )
-
-    api.add_badge(
-        "TestBadge-6 deer",
-        "TestImage-5",
-        "A test badge for doing 600 unit tests",
-        "TestCriteria",
-        dummy_issuer_id,
-        tags="tag2, tag4",
-    )
+    dummy_badges_for_search_string(api, dummy_issuer_id)
 
     badges = list(api.get_badges_by_search_string(search_string, begin, limit))
     assert len(badges) == expected_count
@@ -800,7 +720,41 @@ def test_get_badges_by_search_string(
 @pytest.mark.parametrize(
     "search_string, begin, limit, expected_count",
     [
-        ("", None, None, 6),  # tuples with "" checks the correctness of the pagination
+        ("test badge", 0, 6, 6),
+        ("rabbit panda", 0, 6, 1),
+        ("rabbit", 0, 6, 3),
+        ("deer", 0, 6, 2),
+        ("moose", 0, 6, 0),
+        ("600", 0, 6, 1),
+        ("60", 0, 6, 2),
+        ("500", 0, 6, 0),
+        ("tag", 0, 6, 6),
+        ("tag4", 0, 6, 3),
+        ("tag0", 0, 6, 0),
+        ("tag3", 0, 6, 1),
+        (90, 0, 6, 0),
+        (None, 0, 6, 0),
+    ],
+)
+def test_get_badges_by_search_string_filter(
+    api, search_string, begin, limit, expected_count, dummy_issuer_id
+):
+    """Test for the filtration function of get_badges_by_search_string_filter"""
+
+    dummy_badges_for_search_string(api, dummy_issuer_id)
+
+    badges = list(api.get_badges_by_search_string(search_string, begin, limit))
+    assert len(badges) == expected_count
+
+    if len(badges) > 1:
+        assert badges[0].created_on >= badges[1].created_on
+        assert badges[0].created_on >= badges[-1].created_on
+
+
+@pytest.mark.parametrize(
+    "search_string, begin, limit, expected_count",
+    [
+        ("", None, None, 6),
         ("", 0, 3, 3),
         ("", 4, 2, 2),
         ("", 3, 3, 3),
@@ -811,17 +765,13 @@ def test_get_badges_by_search_string(
         ("", None, 0, 0),
         ("", 0, 1, 1),
         ("", "one", "two", 6),
-        ("jo", 0, 6, 2),  # tuples below test for correct filteration
-        ("ane", 0, 6, 2),
-        ("0x", 0, 6, 1),
-        (90, 0, 6, 0),
-        (0, 0, 6, 1),
-        (None, 0, 6, 0),
     ],
 )
-def test_get_persons_by_search_string(
-    api, initialize_dummy_persons, search_string, begin, limit, expected_count
-):
+def test_get_persons_by_search_string_pagination(api, search_string, begin, limit, expected_count):
+    """Test for the pagination function of get_persons_by_search_string"""
+
+    dummy_persons_for_search_string(api)
+
     persons = list(
         api.get_persons_by_search_string(search_string, begin, limit, include_opted_out=True)
     )
@@ -835,3 +785,25 @@ def test_get_persons_by_search_string(
         )
         if len(control_batch) == expected_count:
             assert persons[0].id != control_batch[0].id
+
+
+@pytest.mark.parametrize(
+    "search_string, begin, limit, expected_count",
+    [
+        ("jo", 0, 6, 2),
+        ("ane", 0, 6, 2),
+        ("0x", 0, 6, 1),
+        (90, 0, 6, 0),
+        (0, 0, 6, 1),
+        (None, 0, 6, 0),
+    ],
+)
+def test_get_persons_by_search_string_filter(api, search_string, begin, limit, expected_count):
+    """Test for the filtration function of get_persons_by_search_string"""
+
+    dummy_persons_for_search_string(api)
+
+    persons = list(
+        api.get_persons_by_search_string(search_string, begin, limit, include_opted_out=True)
+    )
+    assert len(persons) == expected_count


### PR DESCRIPTION
## Overview
This Pull Request optimizes the `get_all_badges` and `get_all_persons` in the `dbapi.py` file. The functions were optimized to handle search queries and pagination at db level. 
Tests were also written for the affected endpoints in the the `test_dbapi.py` file. The functions are `test_get_all_persons` and `test_get_all_badges`.

**No Ai tools were used.**

closes #273 

## Changes
The changes below were made:

- The function header of  `get_all_badges` has been updated to this:

```
def get_all_badges(
        self,
        search_string: Optional[str] = None,
        begin: Optional[int] = None,
        limit: Optional[int] = None,
    )
```
The function header of `get_all_persons` has been updated to this:
```
def get_all_persons(
        self,
        search_string: Optional[str] = None,
        begin: Optional[int] = None,
        limit: Optional[int] = None,
        include_opted_out=False,
    ):
```
- Filtration of search_query for both functions is now moved into the db function to ensure pagination is applied to a filtered request not all of the data set.
- The functions now accepts `begin` and `limit` which are used to paginated the db request

These changes handle the query and pagination once at the db level, and the issue of querying all of the dataset before filtration has been resolved. This would handle a large dataset well
### Tests
There weren't any tests present for the two database functions, but I have updated that. The tests I implemented covers all possible situations that could be encountered during filtration, and pagination for `get_all_badges` and `get_all_persons`. The test functions are parameterized to make the functions more compact and still retain it's efficiency.


## Next Change
I'll also be updating the tahrir endpoints by refactoring the  `GET /api/badges/search/<search_string>` and `GET /api/users/search/<search_string>`  endpoints to match with this change, in order to avoid a disconnect/error on those endpoints