### PR TITLE
Refactor/get persons by nickname pagination

### DIFF
--- a/tahrir_api/dbapi.py
+++ b/tahrir_api/dbapi.py
@@ -531,6 +531,33 @@ class TahrirDatabase:
             query = query.filter(not_(Person.opt_out))
         return query
 
+    def get_persons_by_nickname(self, search_string: str, begin: int = 0, limit: int = 100):
+        """
+        Search for persons by nickname with pagination.
+
+        :type search_string: str
+        :param search_string: The nickname pattern to search for.
+        :type begin: int
+        :param begin: Offset for pagination (default 0).
+        :type limit: int
+        :param limit: Max results per page, capped at 100 (default 100).
+        """
+
+        safe_limit = min(limit, 100)
+
+        query = self.session.query(Person).filter(
+            func.lower(Person.nickname).like(f"%{search_string.lower()}%")
+        )
+
+        total_count = query.count()
+        paginated_results = query.offset(begin).limit(safe_limit).all()
+        return {
+            "users": paginated_results,
+            "total": total_count,
+            "begin": begin,
+            "limit": safe_limit,
+        }
+
     def get_person_email(self, person_id):
         """
         Convience function to retrieve a person email from an id.

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -675,3 +675,45 @@ def test_get_all_series_empty(api):
     series_query = api.get_all_series()
     series_list = list(series_query)
     assert len(series_list) == 0
+
+
+@pytest.mark.parametrize(
+    "search_string, expected_total, expected_nicknames",
+    [
+        ("alice", 1, ["alice_wonder"]),
+        ("test", 2, ["dave_test", "diana_test"]),
+        ("zzznomatch", 0, []),
+        ("uppercase", 1, ["UpperCase"]),
+    ],
+)
+def test_get_persons_by_nickname_search(api, search_string, expected_total, expected_nicknames):
+    api.add_person("alice@test.com", nickname="alice_wonder")
+    api.add_person("dave@test.com", nickname="dave_test")
+    api.add_person("diana@test.com", nickname="diana_test")
+    api.add_person("upper@test.com", nickname="UpperCase")
+
+    result = api.get_persons_by_nickname(search_string)
+
+    assert result["total"] == expected_total
+    nicknames = [p.nickname for p in result["users"]]
+    assert nicknames == expected_nicknames
+
+
+@pytest.mark.parametrize(
+    "begin, limit, expected_count",
+    [
+        (0, 2, 2),
+        (2, 2, 2),
+        (4, 2, 1),
+    ],
+)
+def test_get_persons_by_nickname_pagination(api, begin, limit, expected_count):
+    for i in range(5):
+        api.add_person(f"user{i}@test.com", nickname=f"user_{i}")
+
+    result = api.get_persons_by_nickname("user", begin=begin, limit=limit)
+
+    assert len(result["users"]) == expected_count
+    assert result["total"] == 5
+    assert result["begin"] == begin
+    assert result["limit"] == limit


### PR DESCRIPTION
solves #277

I added the logic query for the database to the api where the database does the slicing itself rather than python on the endpoint. this is more efficient since you will not have to fetch all the results after you search something it just narrows down to a number until you get what you want.

here is a short example of it in play 
<img width="1481" height="1018" alt="image" src="https://github.com/user-attachments/assets/e5d51e24-11f5-42f0-a378-46204a696048" />
