### PR TITLE
feat: normalize tags into separate tables

### DIFF
--- a/tahrir_api/migrations/versions/b416f5f62e33_normalize_tags_into_separate_tables.py
+++ b/tahrir_api/migrations/versions/b416f5f62e33_normalize_tags_into_separate_tables.py
@@ -1,0 +1,61 @@
+"""Normalize tags into separate tables
+
+Revision ID: b416f5f62e33
+Revises: 459d4cc47d13
+Create Date: 2026-04-11 00:44:19.634395
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+
+# revision identifiers, used by Alembic.
+revision = 'b416f5f62e33'
+down_revision = '459d4cc47d13'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('tags',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.Unicode(length=64), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_tags')),
+        sa.UniqueConstraint('name', name=op.f('uq_tags_name'))
+    )
+    
+    op.create_table('badge_tags',
+        sa.Column('badge_id', sa.Unicode(length=128), nullable=False),
+        sa.Column('tag_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['badge_id'], ['badges.id'], name=op.f('fk_badge_tags_badge_id_badges'), ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['tag_id'], ['tags.id'], name=op.f('fk_badge_tags_tag_id_tags'), ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('badge_id', 'tag_id', name=op.f('pk_badge_tags'))
+    )
+
+    op.create_table('series_tags',
+        sa.Column('series_id', sa.Unicode(length=128), nullable=False),
+        sa.Column('tag_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['series_id'], ['series.id'], name=op.f('fk_series_tags_series_id_series'), ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['tag_id'], ['tags.id'], name=op.f('fk_series_tags_tag_id_tags'), ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('series_id', 'tag_id', name=op.f('pk_series_tags'))
+    )
+
+    with op.batch_alter_table('badges', schema=None) as batch_op:
+        batch_op.drop_column('tags')
+
+    with op.batch_alter_table('series', schema=None) as batch_op:
+        batch_op.drop_column('tags')
+
+
+def downgrade():
+    with op.batch_alter_table('series', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tags', sa.Unicode(length=128), nullable=True))
+
+    with op.batch_alter_table('badges', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tags', sa.Unicode(length=128), nullable=True))
+
+    op.drop_table('series_tags')
+    op.drop_table('badge_tags')
+    op.drop_table('tags')
+    # ### end Alembic commands ###

--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -6,7 +6,7 @@ import uuid
 import arrow
 import pygments
 import simplejson
-from sqlalchemy import Column, DateTime, ForeignKey, select, Unicode, UniqueConstraint
+from sqlalchemy import Column, DateTime, ForeignKey, select, Unicode, UniqueConstraint, Table
 from sqlalchemy.orm import object_session, relationship
 from sqlalchemy.types import Boolean, Integer
 from sqlalchemy_helpers import Base as DeclarativeBase
@@ -42,6 +42,31 @@ def generate_default_id(context):
     return context.current_parameters["name"].lower().replace(" ", "-")
 
 
+# Association table for Badge - Tag
+badge_tags_association = Table(
+    "badge_tags",
+    DeclarativeBase.metadata,
+    Column("badge_id", Unicode(128), ForeignKey("badges.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+)
+
+# Association table for Series - Tag
+series_tags_association = Table(
+    "series_tags",
+    DeclarativeBase.metadata,
+    Column("series_id", Unicode(128), ForeignKey("series.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+)
+
+class Tag(DeclarativeBase):
+    __tablename__ = "tags"
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode(64), nullable=False, unique=True)
+
+    def __str__(self):
+        return str(self.name)
+
+
 class Badge(DeclarativeBase):
     __tablename__ = "badges"
     id = Column(Unicode(128), primary_key=True, default=generate_default_id)
@@ -57,7 +82,7 @@ class Badge(DeclarativeBase):
     invitations = relationship("Invitation", backref="badge")
     current_values = relationship("CurrentValue", back_populates="badge")
     created_on = Column(DateTime, nullable=False, default=datetime.datetime.now)
-    tags = Column(Unicode(128))
+    tags = relationship("Tag", secondary=badge_tags_association, backref="badges")
 
     def __str__(self):
         return str(self.name)
@@ -75,7 +100,7 @@ class Badge(DeclarativeBase):
             criteria=self.criteria,
             issuer=self.issuer.as_dict(),
             created_on=time.mktime(self.created_on.timetuple()),
-            tags=self.tags,
+            tags=[tag.name for tag in self.tags],
         )
 
     def authorized(self, person):
@@ -110,7 +135,7 @@ class Series(DeclarativeBase):
         default=datetime.datetime.now,
         onupdate=datetime.datetime.now,
     )
-    tags = Column(Unicode(128))
+    tags = relationship("Tag", secondary=series_tags_association, backref="series")
     milestone = relationship("Milestone", backref="series")
     team_id = Column(Unicode(128), ForeignKey("team.id"), nullable=False)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 import pytest
-from sqlalchemy import inspect
+from sqlalchemy import inspect, create_engine
 from sqlalchemy.exc import NoInspectionAvailable
-from sqlalchemy.orm import Mapper
+from sqlalchemy.orm import Mapper, sessionmaker
 
 from tahrir_api import model
 
@@ -33,3 +33,53 @@ def get_models_columns_with_defaults():
 def test_safe_column_default(column):
     if getattr(column.default, "is_callable", False):
         column.default.arg(None)
+
+def test_tag_normalization_relationships():
+    engine = create_engine("sqlite:///:memory:")
+    model.DeclarativeBase.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Create Tags
+    tag_dev = model.Tag(name="developer")
+    tag_web = model.Tag(name="web")
+    session.add_all([tag_dev, tag_web])
+    
+    # Create Issuer and Team 
+    issuer = model.Issuer(origin="org", name="Org", org="Org", contact="c@o.com")
+    team = model.Team(id="team-1", name="Team One")
+    session.add_all([issuer, team])
+    session.flush()
+
+    # Create Badge and Series
+    badge = model.Badge(
+        id="b1", name="B1", image="i.png", description="D", 
+        criteria="C", issuer_id=issuer.id
+    )
+    series = model.Series(
+        id="s1", name="S1", description="D", team_id=team.id
+    )
+
+    # Associate Tags 
+    badge.tags.append(tag_dev)
+    badge.tags.append(tag_web)
+    series.tags.append(tag_dev)
+    
+    session.add_all([badge, series])
+    session.commit()
+
+    # Assertions
+    # Test Badge many-to-many
+    assert len(badge.tags) == 2
+    assert tag_dev in badge.tags
+    assert tag_web in badge.tags
+
+    # Test Series many-to-many
+    assert len(series.tags) == 1
+    assert tag_dev in series.tags
+
+    # Test the backrefs 
+    assert badge in tag_dev.badges
+    assert series in tag_dev.series
+    
+    session.close()


### PR DESCRIPTION
Fixes #78 

This PR modernizes how tags are handled by moving them from simple strings into a proper database structure.

### The Problem
Storing tags as comma-separated strings (e.g., "web,api") made it impossible to search for tags efficiently and led to inconsistent data across the app.

### Fix
- Created tags table and two bridge tables (badge_tags and series_tags) to handle the new Many-to-Many relationships.
- Updated the models to use relationship() and backref, allowing you to easily access tags from a badge (and vice versa).
- Migration
- Added tests to verify that tags can be created, linked, and retrieved correctly in both directions.

<img width="960" height="161" alt="Screenshot 2026-04-11 013537" src="https://github.com/user-attachments/assets/418b648d-75a5-433e-b792-1985b3f047af" />


