### PR TITLE
docs: update dev setup guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,100 +11,149 @@ interact with the database. The model is used for a slightly more low level way
 of interacting with the database. It allows for custom interactions with the
 database without having to use the ``TahrirDatabase`` class.
 
-Creating a Badge
-================
-
-This is an example of creating a badge via Tahrir-API:
-
-.. code-block:: python
-
-    from tahrir_api.dbapi import TahrirDatabase
-
-
-    db = TahrirDatabase('backend://badges:badgesareawesome@localhost/badges')
-
-    origin = 'http://foss.rit.edu/badges'
-    issuer_name = 'FOSS@RIT'
-    org = 'http://foss.rit.edu'
-    contact = 'foss@rit.edu'
-
-    issuer_id = db.add_issuer(origin, issuer_name, org, contact)
-
-    badge_name = 'fossbox'
-    image = 'http://foss.rit.edu/files/fossboxbadge.png'
-    desc = 'Welcome to the FOSSBox. A member is you!'
-    criteria = 'http://foss.rit.edu'
-
-    db.add_badge(badge_name, image, desc, criteria, issuer_id)
-
-
-Awarding a Badge
-================
-
-This is an example of awarding a badge via Tahrir-API:
-
-.. code-block:: python
-
-    from tahrir_api.dbapi import TahrirDatabase
-
-
-    db = TahrirDatabase('backend://badges:badgesareawesome@localhost/badges')
-
-    badge_id = 'fossbox'
-    person_email = 'person@email.com'
-    issued_on = None
-
-    db.add_person(person_email)
-    db.add_assertion(badge_id, person_email, issued_on)
-
-
 Development
 ===========
 
-Set-up your env
----------------
-Install helper
+System Requirements
+-------------------
+
+Before getting started, ensure your system meets the following requirements:
+
+**Software Requirements**
+
+- **Python**: 3.9 or higher 
+- **Poetry**: Latest version for dependency management
+- **Database**: PostgreSQL 9.6+ (recommended) or SQLite (basic development)
+- **Git**: For version control
+
+**Operating System Requirement**
+
+- **Fedora Linux**: Latest non-EOL versions
+
+Note: Other distributions may work, but are not officially supported. The maintainers may not be able to assist with platform-specific issues on non-Fedora systems.
+
+Project Setup
+-------------
+1. Ensure that the necessary packages are installed:
 
 .. code-block:: bash
 
-    $ sudo dnf install -y python3-virtualenvwrapper  # RedHat-based OS
+    $ sudo dnf install -y python3 python3-pip python3-devel poetry gcc krb5-devel git
 
-Build your virtual env
-
-.. code-block:: bash
-
-    $ export WORKON_HOME=$HOME/.virtualenvs
-    $ mkvirtualenv tahrir-api
-
-Connect w/ your virutal env
+2. Clone your fork to the local storage and make it your current working directory:
 
 .. code-block:: bash
 
-    $ workon tahrir-api
-    (tahrir-api)$
+    $ git clone https://github.com/fedora-infra/tahrir-api.git
+    $ cd tahrir-api
 
-Install
--------
-Requirements
+3. Create a virtual environment and activate it for installing project dependencies:
 
 .. code-block:: bash
 
-    (tahrir-api)$ pip install -r requirements.txt
+    $ python3 -m venv venv
+    $ source venv/bin/activate
 
-Project installation
+4. Install project dependencies:
 
 .. code-block:: bash
 
-    (tahrir-api)$ python setup.py develop
+    (venv) $ poetry check
+    (venv) $ poetry install
 
-Happy hacking!
+
+Database Setup
+--------------
+
+1. Create a directory for storing the Tahrir database snapshot:
+
+.. code-block:: bash
+
+    (venv) $ cd ..
+    (venv) $ mkdir badges-database
+    (venv) $ cd badges-database
+
+2. Download and extract the Tahrir database snapshot:
+
+.. code-block:: bash
+
+    (venv) $ wget https://infrastructure.fedoraproject.org/infra/db-dumps/tahrir.dump.xz
+    (venv) $ unxz tahrir.dump.xz
+
+3. Create directories for persistent data and the database dump:
+
+.. code-block:: bash
+
+    (venv) $ mkdir data dump
+    (venv) $ mv tahrir.dump dump/
+
+4. Pull the PostgreSQL container image:
+
+.. code-block:: bash
+
+    (venv) $ podman pull docker.io/library/postgres:15
+
+5. Start the database container (be sure to rename the username and paths based on your development environment):
+
+.. code-block:: bash
+
+    (venv) $ podman run \
+        --name badges-database \
+        --env POSTGRES_USER=badgesdb \
+        --env POSTGRES_PASSWORD=badgesdb \
+        --env POSTGRES_DB=badgesdb \
+        --env PGDATA=/var/lib/postgresql/data/pgdata \
+        --volume /home/username/Projects/badges-database/data:/var/lib/postgresql/data:Z \
+        --volume /home/username/Projects/badges-database/dump:/badgesdb:Z \
+        --publish 5432:5432 \
+        --restart unless-stopped \
+        --detach docker.io/library/postgres:15
+
+6. Once the database container has started, log in to the interactive shell using the password to begin importing the extracted dump:
+
+.. code-block:: bash
+
+   (venv )$ podman pull docker.io/library/postgres:15
+   (venv )$ podman run \
+
+7. Execute the following SQL commands to create roles, load the database dump, and grant the needed access:
+
+.. code-block:: sql
+
+    badgesdb=# create role "tahrir" with inherit nocreatedb nocreaterole noreplication nosuperuser valid until 'infinity' login password 'tahrir';
+    badgesdb=# create role "tahrir-readonly" with nocreatedb inherit nocreaterole noreplication nosuperuser valid until 'infinity' login password 'tahrir-readonly';
+    badgesdb=# \i badgesdb/tahrir.dump
+    badgesdb=# grant connect on database tahrir to "tahrir";
+    badgesdb=# grant all on all tables in schema public to "tahrir";
+    badgesdb=# grant all on all sequences in schema public to "tahrir";
+    badgesdb=# revoke create on schema public from public;
+
+8. Exit out of the interactive shell and log back in using the newly created credentials:
+
+.. code-block:: bash
+
+     (venv )$ podman exec -ti badges-database psql --username badgesdb --password
+
+9. Verify the database setup:
+
+.. code-block:: sql
+
+    (venv )$ tahrir=> \dt+
 
 Run the tests
 -------------
 
-You can run the tests with ``tox``
+1. Download and install ``tox``:
 
 .. code-block:: bash
 
-    (tahrir-api)$ pip install tox
-    (tahrir-api)$ tox
+    (venv) $ cd ./tahrir-api
+    (venv) $ sudo dnf install tox
+
+2. Run the tests with ``tox``:
+
+.. code-block:: bash
+
+    (venv) $ tox
+
+


### PR DESCRIPTION
The existing setup instructions in README.rst are outdated and no longer
work on a fresh Fedora instance. This PR replaces them with a validated
setup guide based on testing in a clean Fedora 43 container.

Issues found with the current guide:
- requirements.txt does not exist (project uses pyproject.toml)
- setup.py does not exist (deprecated, replaced by pip install -e .)
- poetry not listed as a prerequisite for running tox
- System dependencies (gcc, python3-devel, krb5-devel) not documented
- Missing virtual environment setup steps

Changes made:
- Added system requirements section for Fedora and Debian based systems
- Replaced pip install -r requirements.txt with pip install -e .
- Removed python setup.py develop (covered by pip install -e .)
- Added virtual environment setup using python3 -m venv
- Added pip install tox poetry to run tests
- Added database setup guide using Podman and the Fedora badges DB dump

All steps validated on a fresh Fedora 43 container.

closes #276 