### PR TITLE
Use actual FK constraint name in cascade migration

### DIFF
--- a/tahrir_api/migrations/versions/53b73809290f_add_ondelete_cascade_to_badge_assertions.py
+++ b/tahrir_api/migrations/versions/53b73809290f_add_ondelete_cascade_to_badge_assertions.py
@@ -16,13 +16,13 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table("assertions", schema=None) as batch_op:
-        batch_op.drop_constraint("fk_assertions_badge_id_badges", type_="foreignkey")
+        batch_op.drop_constraint("assertions_badge_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
-            "fk_assertions_badge_id_badges", "badges", ["badge_id"], ["id"], ondelete="CASCADE"
+            "assertions_badge_id_fkey", "badges", ["badge_id"], ["id"], ondelete="CASCADE"
         )
 
 
 def downgrade():
     with op.batch_alter_table("assertions", schema=None) as batch_op:
-        batch_op.drop_constraint("fk_assertions_badge_id_badges", type_="foreignkey")
-        batch_op.create_foreign_key("fk_assertions_badge_id_badges", "badges", ["badge_id"], ["id"])
+        batch_op.drop_constraint("assertions_badge_id_fkey", type_="foreignkey")
+        batch_op.create_foreign_key("assertions_badge_id_fkey", "badges", ["badge_id"], ["id"])


### PR DESCRIPTION
Use actual FK constraint name in cascade migration

