### PR TITLE
Eliminate `exists-then-get` redundant queries

### DIFF
--- a/tahrir_api/db/assertion.py
+++ b/tahrir_api/db/assertion.py
@@ -160,38 +160,37 @@ class AssertionMethod:
         if issued_on is None:
             issued_on = datetime.now(timezone.utc)
 
-        if self.person_exists(email=person_email) and self.badge_exists(badge_id):
-            badge = self.get_badge(badge_id)
+        badge = self.get_badge(badge_id)
+        person = self.get_person(person_email)
 
-            if badge.legacy:
-                raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be awarded")
+        if not badge or not person:
+            return False
 
-            person = self.get_person(person_email)
+        if badge.legacy:
+            raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be awarded")
 
-            new_assertion = Assertion(
-                badge_id=badge_id,
-                person_id=person.id,
-                issued_on=issued_on,
-                issued_for=issued_for,
+        new_assertion = Assertion(
+            badge_id=badge_id,
+            person_id=person.id,
+            issued_on=issued_on,
+            issued_for=issued_for,
+        )
+        self.session.add(new_assertion)
+        self.session.flush()
+
+        if self.notification_callback:
+            body = dict(
+                badge=dict(
+                    name=badge.name,
+                    description=badge.description,
+                    image_url=badge.image,
+                    badge_id=badge_id,
+                ),
+                user=dict(username=person.nickname, badges_user_id=person.id),
             )
-            self.session.add(new_assertion)
-            self.session.flush()
+            self.notification_callback(BadgeAwardV1(body=body))
 
-            if self.notification_callback:
-                body = dict(
-                    badge=dict(
-                        name=badge.name,
-                        description=badge.description,
-                        image_url=badge.image,
-                        badge_id=badge_id,
-                    ),
-                    user=dict(username=person.nickname, badges_user_id=person.id),
-                )
-                self.notification_callback(BadgeAwardV1(body=body))
-
-            return person_email, badge_id
-
-        return False
+        return person_email, badge_id
 
     @autocommit
     def remove_assertion(self, badge_id, person_email):
@@ -207,10 +206,9 @@ class AssertionMethod:
         :returns: True if successful, False otherwise
         """
 
-        if not self.person_exists(email=person_email):
-            return False
-
         person = self.get_person(person_email)
+        if not person:
+            return False
 
         assertion = (
             self.session.query(Assertion).filter_by(person_id=person.id, badge_id=badge_id).first()

--- a/tahrir_api/db/authorization.py
+++ b/tahrir_api/db/authorization.py
@@ -40,21 +40,20 @@ class AuthorizationMethod:
         :param person_email: Email of the Person grant rights to
         """
 
-        if self.person_exists(email=person_email) and self.badge_exists(badge_id):
-            badge = self.get_badge(badge_id)
+        badge = self.get_badge(badge_id)
+        person = self.get_person(person_email)
 
-            if badge.legacy:
-                raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be authorized")
+        if not badge or not person:
+            return False
 
-            person = self.get_person(person_email)
+        if badge.legacy:
+            raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be authorized")
 
-            new_authz = Authorization(badge_id=badge_id, person_id=person.id)
-            self.session.add(new_authz)
-            self.session.flush()
+        new_authz = Authorization(badge_id=badge_id, person_id=person.id)
+        self.session.add(new_authz)
+        self.session.flush()
 
-            return (person_email, badge_id)
-
-        return False
+        return (person_email, badge_id)
 
     @autocommit
     def delete_authorization(self, badge_id, person_email):

--- a/tahrir_api/db/badge.py
+++ b/tahrir_api/db/badge.py
@@ -17,15 +17,15 @@ class BadgeMethod:
         :type include_legacy: boolean
         :param include_legacy: Include legacy badges in results (default: False)
         """
-        if self.team_exists(team_id):
-            series = self.get_series_from_team(team_id)
-            series_ids = [elem.id for elem in series]
+        series = self.get_series_from_team(team_id)
+        if not series:
+            return []
 
-            milestones = self.get_milestone_from_series_ids(series_ids)
-            badge_ids = list(set([milestone.badge_id for milestone in milestones]))
+        series_ids = [elem.id for elem in series]
+        milestones = self.get_milestone_from_series_ids(series_ids)
+        badge_ids = list(set([milestone.badge_id for milestone in milestones]))
 
-            return self.get_badges(badge_ids, include_legacy=include_legacy)
-        return None
+        return self.get_badges(badge_ids, include_legacy=include_legacy)
 
     def badge_exists(self, badge_id):
         """
@@ -48,11 +48,9 @@ class BadgeMethod:
         :param badge_id: The ID of the badge to return
         """
 
-        if self.badge_exists(badge_id):
-            return (
-                self.session.query(Badge).filter(func.lower(Badge.id) == func.lower(badge_id)).one()
-            )
-        return None
+        return (
+            self.session.query(Badge).filter(func.lower(Badge.id) == func.lower(badge_id)).first()
+        )
 
     def get_badges(self, badge_ids, include_legacy=False):
         """
@@ -133,14 +131,14 @@ class BadgeMethod:
         :raises ValueError: If the badge is marked as legacy
         """
 
-        if self.badge_exists(badge_id):
-            to_delete = self.session.query(Badge).filter_by(id=badge_id).one()
-            if to_delete.legacy:
-                raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be deleted")
-            self.session.delete(to_delete)
-            self.session.flush()
-            return badge_id
-        return False
+        badge = self.session.query(Badge).filter_by(id=badge_id).first()
+        if not badge:
+            return False
+        if badge.legacy:
+            raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be deleted")
+        self.session.delete(badge)
+        self.session.flush()
+        return badge_id
 
     @autocommit
     def add_badge(self, name, image, desc, criteria, issuer_id, tags=None, badge_id=None):

--- a/tahrir_api/db/invitation.py
+++ b/tahrir_api/db/invitation.py
@@ -26,18 +26,18 @@ class InvitationMethod:
 
         """
 
-        if not self.badge_exists(badge_id):
-            raise ValueError(f"No such badge {badge_id!r}")
-
         badge = self.get_badge(badge_id)
+        if not badge:
+            raise ValueError(f"No such badge {badge_id!r}")
         if badge.legacy:
             raise ValueError(f"Badge {badge_id!r} is a legacy badge and cannot be invited")
 
         created_on = created_on or datetime.now(timezone.utc)
         expires_on = expires_on or (created_on + timedelta(hours=1))
-        if not created_by_email or not self.person_exists(email=created_by_email):
+        creator = self.get_person(created_by_email) if created_by_email else None
+        if not creator:
             raise ValueError(f"No user with email {created_by_email!r}. Ask them to login first.")
-        created_by = self.get_person(created_by_email).id
+        created_by = creator.id
 
         invitation = Invitation(
             created_on=created_on,
@@ -74,10 +74,10 @@ class InvitationMethod:
         :param invitation_id: The unique ID of this invitation
         """
 
-        if self.invitation_exists(invitation_id):
-            return self.session.query(Invitation).filter_by(id=invitation_id).one()
-        else:
-            return False
+        invitation = self.session.query(Invitation).filter_by(id=invitation_id).first()
+        if invitation:
+            return invitation
+        return False
 
     def get_invitations(self, person_id):
         """
@@ -101,10 +101,9 @@ class InvitationMethod:
         :returns: True if invitation was expired, False if not found
         :rtype: bool
         """
-        if not self.invitation_exists(invitation_id):
+        invitation = self.session.query(Invitation).filter_by(id=invitation_id).first()
+        if not invitation:
             return False
-
-        invitation = self.session.query(Invitation).filter_by(id=invitation_id).one()
         invitation.expires_on = datetime.now()
         self.session.flush()
         return True

--- a/tahrir_api/db/issuer.py
+++ b/tahrir_api/db/issuer.py
@@ -22,10 +22,7 @@ class IssuerMethod:
         :type issuer_id: int
         :param issuer_id: ID of the issuer to return
         """
-        query = self.session.query(Issuer).filter_by(id=issuer_id)
-        if query.count() > 0:
-            return query.one()
-        return None
+        return self.session.query(Issuer).filter_by(id=issuer_id).first()
 
     @autocommit
     def delete_issuer(self, issuer_id):
@@ -36,13 +33,12 @@ class IssuerMethod:
         :param issuer_id: ID of the issuer to be delete
         """
 
-        query = self.session.query(Issuer).filter_by(id=issuer_id)
-        if query.count() > 0:
-            to_delete = query.one()
-            self.session.delete(to_delete)
-            self.session.flush()
-            return issuer_id
-        return False
+        issuer = self.session.query(Issuer).filter_by(id=issuer_id).first()
+        if not issuer:
+            return False
+        self.session.delete(issuer)
+        self.session.flush()
+        return issuer_id
 
     @autocommit
     def add_issuer(self, origin, name, org, contact):
@@ -62,13 +58,14 @@ class IssuerMethod:
         :param contact: The Contact email for this issuer
         """
 
-        if not self.issuer_exists(origin, name):
-            new_issuer = Issuer(origin=origin, name=name, org=org, contact=contact)
-            self.session.add(new_issuer)
-            self.session.flush()
-            return new_issuer.id
+        issuer = self.session.query(Issuer).filter_by(origin=origin, name=name).first()
+        if issuer:
+            return issuer.id
 
-        return self.session.query(Issuer).filter_by(name=name, origin=origin).one().id
+        new_issuer = Issuer(origin=origin, name=name, org=org, contact=contact)
+        self.session.add(new_issuer)
+        self.session.flush()
+        return new_issuer.id
 
     def get_all_issuers(self):
         """

--- a/tahrir_api/db/person.py
+++ b/tahrir_api/db/person.py
@@ -101,13 +101,9 @@ class PersonMethod:
         :param person_id: The email of a Person in the database.
         """
 
-        if self.person_exists(id=person_id):
-            return (
-                self.session.query(Person)
-                .filter(func.lower(Person.id) == func.lower(person_id))
-                .one()
-                .email
-            )
+        person = self.session.query(Person).filter_by(id=person_id).first()
+        if person:
+            return person.email
         return None
 
     def get_person(self, person_email=None, id=None, nickname=None):
@@ -127,14 +123,13 @@ class PersonMethod:
 
         query = self.session.query(Person)
 
-        if person_email and self.person_exists(email=person_email):
-            return query.filter(func.lower(Person.email) == func.lower(person_email)).one()
-        elif id and self.person_exists(id=id):
-            return query.filter_by(id=id).one()
-        elif nickname and self.person_exists(nickname=nickname):
-            return query.filter(func.lower(Person.nickname) == func.lower(nickname)).one()
-        else:
-            return None
+        if person_email:
+            return query.filter(func.lower(Person.email) == func.lower(person_email)).first()
+        elif id:
+            return query.filter_by(id=id).first()
+        elif nickname:
+            return query.filter(func.lower(Person.nickname) == func.lower(nickname)).first()
+        return None
 
     @autocommit
     def delete_person(self, person_email):
@@ -145,11 +140,12 @@ class PersonMethod:
         :param person_email: Email of the person to delete
         """
 
-        if self.person_exists(email=person_email):
-            self.session.delete(self.get_person(person_email))
-            self.session.flush()
-            return person_email
-        return False
+        person = self.get_person(person_email)
+        if not person:
+            return False
+        self.session.delete(person)
+        self.session.flush()
+        return person_email
 
     @autocommit
     def add_person(self, email, nickname=None, website=None, bio=None, avatar=None):

--- a/tahrir_api/db/series.py
+++ b/tahrir_api/db/series.py
@@ -30,13 +30,11 @@ class SeriesMethod:
         :param series_id: The ID of the series to return
         """
 
-        if self.series_exists(series_id):
-            return (
-                self.session.query(Series)
-                .filter(func.lower(Series.id) == func.lower(series_id))
-                .one()
-            )
-        return None
+        return (
+            self.session.query(Series)
+            .filter(func.lower(Series.id) == func.lower(series_id))
+            .first()
+        )
 
     def get_series_from_team(self, team_id):
         """
@@ -45,8 +43,7 @@ class SeriesMethod:
         :type team_id: str
         :param team_id: The ID of the team
         """
-        if self.team_exists(team_id):
-            return self.session.query(Series).filter(Series.team_id == team_id).all()
+        return self.session.query(Series).filter(Series.team_id == team_id).all()
 
     @autocommit
     def create_series(self, name, desc, team_id, tags=None, series_id=None):

--- a/tahrir_api/db/team.py
+++ b/tahrir_api/db/team.py
@@ -27,11 +27,7 @@ class TeamMethod:
         :param team_id: The ID of the team to return
         """
 
-        if self.team_exists(team_id):
-            return (
-                self.session.query(Team).filter(func.lower(Team.id) == func.lower(team_id)).first()
-            )
-        return None
+        return self.session.query(Team).filter(func.lower(Team.id) == func.lower(team_id)).first()
 
     @autocommit
     def create_team(self, name, team_id=None):

--- a/tests/test_teams_series.py
+++ b/tests/test_teams_series.py
@@ -140,7 +140,7 @@ def test_get_series_from_team(api):
     assert "Test Series Bravo" in series_names
 
     absented_series = api.get_series_from_team("absented-team")
-    assert absented_series is None
+    assert absented_series == []
 
 
 def test_get_badges_from_team(api, dummy_issuer_id):
@@ -199,7 +199,7 @@ def test_get_badges_from_team(api, dummy_issuer_id):
     assert "Test Badge Bravo" in badge_names
 
     absented_badges = api.get_badges_from_team("absented-team")
-    assert absented_badges is None
+    assert absented_badges == []
 
 
 def test_get_series_existing(api):


### PR DESCRIPTION
Replace the pattern of calling `_exists()` `(COUNT)` before fetching the same entity with `.first()` and `None` checks, cutting query count per operation by half or more. Worst case was add_assertion at 7 queries reduced to 2.