### PR TITLE
Introduce indexes on foreign key columns

### DIFF
--- a/tahrir_api/migrations/versions/c8dbbb6c717e_add_indexes_on_foreign_key_columns.py
+++ b/tahrir_api/migrations/versions/c8dbbb6c717e_add_indexes_on_foreign_key_columns.py
@@ -1,0 +1,37 @@
+"""Add indexes on foreign key columns
+
+Revision ID: c8dbbb6c717e
+Revises: 53b73809290f
+Create Date: 2026-07-25 00:00:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8dbbb6c717e"
+down_revision = "53b73809290f"
+branch_labels = None
+depends_on = None
+
+FK_INDEXES = [
+    ("ix_badges_issuer_id", "badges", ["issuer_id"]),
+    ("ix_series_team_id", "series", ["team_id"]),
+    ("ix_milestone_badge_id", "milestone", ["badge_id"]),
+    ("ix_milestone_series_id", "milestone", ["series_id"]),
+    ("ix_invitations_badge_id", "invitations", ["badge_id"]),
+    ("ix_invitations_created_by", "invitations", ["created_by"]),
+    ("ix_authorizations_badge_id", "authorizations", ["badge_id"]),
+    ("ix_authorizations_person_id", "authorizations", ["person_id"]),
+    ("ix_assertions_badge_id", "assertions", ["badge_id"]),
+    ("ix_assertions_person_id", "assertions", ["person_id"]),
+]
+
+
+def upgrade():
+    for index_name, table_name, columns in FK_INDEXES:
+        op.create_index(index_name, table_name, columns)
+
+
+def downgrade():
+    for index_name, table_name, _columns in FK_INDEXES:
+        op.drop_index(index_name, table_name)

--- a/tahrir_api/model.py
+++ b/tahrir_api/model.py
@@ -86,7 +86,7 @@ class Badge(DeclarativeBase):
     stl = Column(Unicode(128))
     description = Column(Unicode(128), nullable=False)
     criteria = Column(Unicode(128), nullable=False)
-    issuer_id = Column(Integer, ForeignKey("issuers.id"), nullable=False)
+    issuer_id = Column(Integer, ForeignKey("issuers.id"), nullable=False, index=True)
     milestone = relationship("Milestone", backref="badge")
     authorizations = relationship("Authorization", backref="badge")
     assertions = relationship("Assertion", backref="badge", passive_deletes=True)
@@ -153,7 +153,7 @@ class Series(DeclarativeBase):
     )
     tags = relationship("Tag", secondary=series_tags, backref="series")
     milestone = relationship("Milestone", backref="series")
-    team_id = Column(Unicode(128), ForeignKey("team.id"), nullable=False)
+    team_id = Column(Unicode(128), ForeignKey("team.id"), nullable=False, index=True)
 
     def as_dict(self):
         return dict(
@@ -171,8 +171,8 @@ class Milestone(DeclarativeBase):
     __table_args__ = (UniqueConstraint("position", "badge_id", "series_id"),)
     id = Column(Integer, unique=True, primary_key=True)
     position = Column(Integer, default=None)
-    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False)
-    series_id = Column(Unicode(128), ForeignKey("series.id"), nullable=False)
+    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False, index=True)
+    series_id = Column(Unicode(128), ForeignKey("series.id"), nullable=False, index=True)
 
     def as_dict(self):
         return dict(
@@ -245,8 +245,8 @@ class Invitation(DeclarativeBase):
     id = Column(Unicode(32), primary_key=True, unique=True, default=invitation_id_default)
     created_on = Column(DateTime, nullable=False)
     expires_on = Column(DateTime, nullable=False)
-    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False)
-    created_by = Column(Integer, ForeignKey("persons.id"), nullable=False)
+    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False, index=True)
+    created_by = Column(Integer, ForeignKey("persons.id"), nullable=False, index=True)
 
     @property
     def expired(self):
@@ -260,8 +260,8 @@ class Invitation(DeclarativeBase):
 class Authorization(DeclarativeBase):
     __tablename__ = "authorizations"
     id = Column(Integer, primary_key=True)
-    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False)
-    person_id = Column(Integer, ForeignKey("persons.id"), nullable=False)
+    badge_id = Column(Unicode(128), ForeignKey("badges.id"), nullable=False, index=True)
+    person_id = Column(Integer, ForeignKey("persons.id"), nullable=False, index=True)
 
 
 class CurrentValue(DeclarativeBase):
@@ -310,8 +310,10 @@ def assertion_id_default(context):
 class Assertion(DeclarativeBase):
     __tablename__ = "assertions"
     id = Column(Unicode(128), primary_key=True, unique=True, default=assertion_id_default)
-    badge_id = Column(Unicode(128), ForeignKey("badges.id", ondelete="CASCADE"), nullable=False)
-    person_id = Column(Integer, ForeignKey("persons.id"), nullable=False)
+    badge_id = Column(
+        Unicode(128), ForeignKey("badges.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    person_id = Column(Integer, ForeignKey("persons.id"), nullable=False, index=True)
     salt = Column(Unicode(128), nullable=False, default=salt_default)
     issued_on = Column(DateTime, nullable=False, default=datetime.datetime.now)
 


### PR DESCRIPTION
10 foreign key columns across 6 tables had no indexes, forcing full table scans on every filtered query. Most impactful are `assertions.badge_id` and `assertions.person_id` — the largest table and most queried columns.